### PR TITLE
fix(styles): prevent file name overflow in `ActionsModalContent`

### DIFF
--- a/components/ActionsModalContent.tsx
+++ b/components/ActionsModalContent.tsx
@@ -11,7 +11,7 @@ const ImageThumbnail = ({ file }: { file: FileInterface }) => (
   <div className="file-details-thumbnail">
     <Thumbnail type={file.type} extension={file.extension} url={file.url} />
     <div className="flex flex-col">
-      <p className="subtitle-2 mb-1">{file.name}</p>
+      <p className="subtitle-2 mb-1 break-words w-[200px]">{file.name}</p>
       <FormattedDateTime date={file.$createdAt} className="caption" />
     </div>
   </div>


### PR DESCRIPTION
Added `break-words` and `w-[200px]` classes to the file name text to ensure wrapping and a fixed width. Improves layout stability and prevents content overflow in `ActionsModalContent`.